### PR TITLE
Exception for news projects

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,15 +1,39 @@
+export enum RESOLUTION_REASONS {
+  'DEV_ENV',
+  'IN_PRODUCTION',
+  'NON_ABC_SCRIPT',
+  'BAD_SCRIPT_URL',
+  'OTHER',
+}
+
 // Checks if a proxy is requested for this project and loads it if required.
 // The returned promise will only resolve if no proxy is loaded.
 export const proxy = (project: string) =>
-  new Promise<void>((resolve, reject) => {
+  new Promise<number>((resolve, reject) => {
     // If we're already in a dev environment, there's nothing to do here.
-    if (process.env.NODE_ENV === 'development') return resolve();
+    if (process.env.NODE_ENV === 'development')
+      return resolve(RESOLUTION_REASONS.DEV_ENV);
+
     // Never run on live/production.
-    if (document.location.host === 'www.abc.net.au') return resolve();
+    if (
+      document.location.host === 'www.abc.net.au' &&
+      !document.location.pathname.match(/news-projects/)
+    )
+      return resolve(RESOLUTION_REASONS.IN_PRODUCTION);
 
     const src = localStorage.getItem('proxy_' + project);
 
     if (src) {
+      let url: URL;
+      try {
+        url = new URL(src);
+      } catch (e) {
+        return resolve(RESOLUTION_REASONS.BAD_SCRIPT_URL);
+      }
+
+      if (url.hostname.match(/abc\.net\.au$/) === null) {
+        return resolve(RESOLUTION_REASONS.NON_ABC_SCRIPT);
+      }
       const scr = document.createElement('script');
       scr.src = src;
       document.head.appendChild(scr);
@@ -18,5 +42,5 @@ export const proxy = (project: string) =>
       return reject(msg);
     }
 
-    resolve();
+    resolve(RESOLUTION_REASONS.OTHER);
   });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,7 +1,62 @@
-import { proxy } from '../src';
+import { proxy, RESOLUTION_REASONS } from '../src';
+
+const PROJECT = 'abc';
+
+beforeEach(() => {
+  process.env.NODE_ENV = 'test';
+  localStorage.clear();
+});
 
 describe('proxy', () => {
   it('returns a promise', () => {
-    expect(proxy('abc')).toBeInstanceOf(Promise);
+    expect(proxy(PROJECT)).toBeInstanceOf(Promise);
+  });
+
+  describe('resolves', () => {
+    it('in dev environment', () => {
+      expect.assertions(1);
+      process.env.NODE_ENV = 'development';
+      return expect(proxy(PROJECT)).resolves.toEqual(
+        RESOLUTION_REASONS.DEV_ENV
+      );
+    });
+
+    // TODO Figure out how to actually test code that reads document.location
+    // it('in production', () => {
+    //   expect.assertions(1);
+    //   return expect(proxy(PROJECT)).resolves.toEqual(
+    //     RESOLUTION_REASONS.IN_PRODUCTION
+    //   );
+    // });
+
+    it('with a bad script URL', () => {
+      expect.assertions(1);
+      localStorage.setItem('proxy_' + PROJECT, 'not a url');
+      return expect(proxy(PROJECT)).resolves.toEqual(
+        RESOLUTION_REASONS.BAD_SCRIPT_URL
+      );
+    });
+
+    it('with a non-ABC script URL', () => {
+      expect.assertions(1);
+      localStorage.setItem(
+        'proxy_' + PROJECT,
+        'https://www.abb.net.au/script.js'
+      );
+      return expect(proxy(PROJECT)).resolves.toEqual(
+        RESOLUTION_REASONS.NON_ABC_SCRIPT
+      );
+    });
+  });
+
+  describe('rejects', () => {
+    it('with a valid proxy config in localStorage', () => {
+      expect.assertions(1);
+      const src = 'https://www.abc.net.au/res/sites/news-projects/blurgh.js';
+      localStorage.setItem('proxy_' + PROJECT, src);
+      return expect(proxy(PROJECT)).rejects.toEqual(
+        '[dev-proxy] Loaded script: ' + src + ` (${PROJECT})`
+      );
+    });
   });
 });


### PR DESCRIPTION
- Enforce first party scripts and except news-projects in production
- Add tests

fixes #1
