### PR TITLE
Support script type module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@size-limit/esbuild-why": "^8.2.4",
         "@size-limit/preset-small-lib": "^8.2.4",
         "@types/jest": "^29.5.1",
+        "@types/node": "^25.6.0",
         "@typescript-eslint/eslint-plugin": "^5.59.2",
         "eslint": "^8.39.0",
         "husky": "^8.0.3",
@@ -1863,10 +1864,14 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.16.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.3.tgz",
-      "integrity": "sha512-OPs5WnnT1xkCBiuQrZA4+YAV4HEJejmHneyraIaxsbev5yCEr6KMwINNFP9wQeFIw8FWcoTqF3vQsa5CDaI+8Q==",
-      "dev": true
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -9077,6 +9082,13 @@
       "engines": {
         "node": ">=12.20"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unique-string": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@size-limit/esbuild-why": "^8.2.4",
     "@size-limit/preset-small-lib": "^8.2.4",
     "@types/jest": "^29.5.1",
+    "@types/node": "^25.6.0",
     "@typescript-eslint/eslint-plugin": "^5.59.2",
     "eslint": "^8.39.0",
     "husky": "^8.0.3",

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ export const domainMatcher = /^(www|newsapp)\.abc\.net\.au$/;
 
 // Checks if a proxy is requested for this project and loads it if required.
 // The returned promise will only resolve if no proxy is loaded.
-export const proxy = (project: string) =>
+export const proxy = (project: string, options: { type?: string } = {}) =>
   new Promise<number>((resolve, reject) => {
     // Never run on live/production.
     if (
@@ -24,6 +24,6 @@ export const proxy = (project: string) =>
     // Load in a cheaky management keyboard shortcut
     import('./main').then(({ manager, init }) => {
       manager();
-      init(project).then(resolve).catch(reject);
+      init(project, options).then(resolve).catch(reject);
     });
   });

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,7 +6,10 @@ declare global {
   }
 }
 
-export const init = (project: string): Promise<RESOLUTION_REASONS> => {
+export const init = (
+  project: string,
+  options: { type?: string } = {}
+): Promise<RESOLUTION_REASONS> => {
   return new Promise((resolve, reject) => {
     // If we're already in a dev environment, there's nothing to do here.
     if (process.env.NODE_ENV === 'development') {
@@ -43,6 +46,9 @@ export const init = (project: string): Promise<RESOLUTION_REASONS> => {
 
     const scr = document.createElement('script');
     scr.src = src;
+    if (options.type) {
+      scr.type = options.type;
+    }
     document.head.appendChild(scr);
     const msg = '[dev-proxy] Loaded script: ' + src + ` (${project})`;
     console.info(msg);


### PR DESCRIPTION
I think this might be a good way to handle local dev with Vite which supports only script type="module". Any objections to adding this capability here? I was building my own thing that pretty much did the same thing except with a ?proxy=https://localhost query string. But this is already built and it works.

I guess we would update the readme too to tell people how to do it like: `proxy('project-name', { type: "module"}).then(init);`

